### PR TITLE
Check for client first

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -12,7 +12,9 @@ function setPeers(peers) {
 
 export function getPeers() {
   return async dispatch => {
-    const peersList = await client.node.execute('getpeerinfo');
-    dispatch(setPeers(peersList));
+    if (client && client.node) {
+      const peersList = await client.node.execute('getpeerinfo');
+      dispatch(setPeers(peersList));
+    }
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpanel/peers-widget",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpanel/peers-widget",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A widget for displaying peer information on the bPanel Dashboard",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes bug where client doesn't have a node client when app first loads and console displays error. 